### PR TITLE
fix #566 and add test

### DIFF
--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -638,3 +638,7 @@ let anotherRecord = {
   name: "joe++",
   age: testRecord.age + 10
 };
+
+/* Requested in #566 */
+let break_after_equal =
+  no_break_from_here (some_call to_here);

--- a/formatTest/unit_tests/input/basicStructures.re
+++ b/formatTest/unit_tests/input/basicStructures.re
@@ -528,3 +528,6 @@ let anotherRecord = {
   name: "joe++",
   age: testRecord.age + 10
 };
+
+/* Requested in #566 */
+let break_after_equal = no_break_from_here (some_call to_here);

--- a/src/reason_pprint_ast.ml
+++ b/src/reason_pprint_ast.ml
@@ -2185,12 +2185,16 @@ let formatCoerce expr optType coerced =
  *       20
  *     );
  *
+ * The outer list wrapping fixes #566: format should break the whole
+ * application before breaking arguments.
  *)
 let formatIndentedApplication headApplicationItem argApplicationItems =
-  label
-    ~space:true
-    headApplicationItem
-    (makeAppList argApplicationItems)
+  makeList ~inline:(true, true) ~postSpace:true ~break:IfNeed [
+    label
+      ~space:true
+      headApplicationItem
+      (makeAppList argApplicationItems)
+  ]
 
 
 (* The loc, is an optional location or the returned app terms *)


### PR DESCRIPTION
Simply wrap applications in their own boxes to give more flexibility to the line breaker.